### PR TITLE
chore:  bump production consumer limits for better throughput

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,10 +11,13 @@ name = "egress-consumer-production"
 
 [[env.production.queues.consumers]]
 queue = "egress-tracking-queue-production"
-max_batch_size = 50
-max_batch_timeout = 30
+max_batch_size = 100  # Increased from 50 to max limit
+max_batch_timeout = 60  # Increased from 30 to max (60 seconds)
 max_retries = 3
 dead_letter_queue = "egress-dlq-production"
+
+[env.production.limits]
+cpu_ms = 300000  # 5 minutes (max CPU time)
 
 [env.production.vars]
 UPLOAD_API_URL = "https://up.storacha.network"


### PR DESCRIPTION
## Bump production consumer limits for better throughput

## Changes
- Increase `max_batch_size`: 50 → 100 (maximum allowed)
- Increase `max_batch_timeout`: 30s → 60s (maximum allowed)
- Add `cpu_ms`: 300,000ms (5 minutes, maximum allowed)

## Rationale

### Batch Size (100 messages)
- **50% reduction** in upload-API requests (100 vs 50 per batch)
- **50% reduction** in Kinesis stream load
- Better utilizes available resources and reduces overhead from CAR encoding

### Batch Timeout (60 seconds)
- Allows the queue to accumulate fuller batches before processing
- Reduces frequency of small batches
- Maximizes throughput during steady-state operation

### CPU Time (5 minutes)
- Provides headroom for processing larger batches (100 messages)
- Prevents timeout issues during CAR file creation and upload

## Impact
These changes prepare the consumer for the production egress rollout by
- Reducing downstream load on upload-API and Kinesis by 50%
- Improving cost efficiency (fewer Lambda invocations)
- Maintaining processing reliability with extended CPU time
